### PR TITLE
Removing some hard-coded absolute paths to pickle files. For now, assume

### DIFF
--- a/NeuralNetDemo.py
+++ b/NeuralNetDemo.py
@@ -1,9 +1,9 @@
 import pickle, numpy
 from PIL import Image
 layers = [None, numpy.zeros(30), numpy.zeros(10)]
-mnist = [pickle.load(open("/Users/jstenger/Desktop/MNIST/mnist_train.pickle", "rb")), pickle.load(open("/Users/jstenger/Desktop/MNIST/mnist_test.pickle", "rb"))]
-weights = [numpy.array(pickle.load(open("/Users/jstenger/Desktop/MNIST/weights_3layerstrained2.pickle", "rb"))[0]), numpy.array(pickle.load(open("/Users/jstenger/Desktop/MNIST/weights_3layerstrained2.pickle", "rb"))[1])]
-biases = [numpy.array(pickle.load(open("/Users/jstenger/Desktop/MNIST/biases_3layerstrained2.pickle", "rb"))[0]), numpy.array(pickle.load(open("/Users/jstenger/Desktop/MNIST/biases_3layerstrained2.pickle", "rb"))[1])]
+mnist = [pickle.load(open("mnist_train.pickle", "rb")), pickle.load(open("mnist_test.pickle", "rb"))]
+weights = [numpy.array(pickle.load(open("weights_3layerstrained2.pickle", "rb"))[0]), numpy.array(pickle.load(open("weights_3layerstrained2.pickle", "rb"))[1])]
+biases = [numpy.array(pickle.load(open("biases_3layerstrained2.pickle", "rb"))[0]), numpy.array(pickle.load(open("biases_3layerstrained2.pickle", "rb"))[1])]
 
 
 def main():

--- a/NeuralNetMain.py
+++ b/NeuralNetMain.py
@@ -1,9 +1,9 @@
 import pickle, numpy
 from PIL import Image
 
-mnist = [pickle.load(open("/Users/jstenger/Desktop/MNIST/mnist_train.pickle", "rb")), pickle.load(open("/Users/jstenger/Desktop/MNIST/mnist_test.pickle", "rb"))]
-weights = pickle.load(open("/Users/jstenger/Desktop/MNIST/untrainedWeights.pickle", "rb")) 
-biases = pickle.load(open("/Users/jstenger/Desktop/MNIST/untrainedBiases.pickle", "rb"))
+mnist = [pickle.load(open("mnist_train.pickle", "rb")), pickle.load(open("mnist_test.pickle", "rb"))]
+weights = pickle.load(open("untrainedWeights.pickle", "rb")) 
+biases = pickle.load(open("untrainedBiases.pickle", "rb"))
 learning_constant = 1
 backprop_constant = 1
 
@@ -19,10 +19,10 @@ def main():
     print("accuracy:" ,testAccuracy(1000))
 
     #save parameters to a new .pickle file
-    biases_pickle = open("/Users/jstenger/Desktop/MNIST/trainedBiases2.pickle", "wb")
+    biases_pickle = open("trainedBiases2.pickle", "wb")
     pickle.dump(biases, biases_pickle)
     biases_pickle.close()
-    weights_pickle = open("/Users/jstenger/Desktop/MNIST/trainedWeights2.pickle", "wb")
+    weights_pickle = open("trainedWeights2.pickle", "wb")
     pickle.dump(weights, weights_pickle)
     biases_pickle.close()
 

--- a/WeightAndBiasGenerator.py
+++ b/WeightAndBiasGenerator.py
@@ -15,10 +15,10 @@ for x in range (10):
 
 
 
-weights_pickle = open("/Users/jstenger/Desktop/MNIST/weights_3layers.pickle", "wb")
+weights_pickle = open("weights_3layers.pickle", "wb")
 pickle.dump(weights, weights_pickle)
 weights_pickle.close()
 
-biases_pickle = open("/Users/jstenger/Desktop/MNIST/biases_3layers.pickle", "wb")
+biases_pickle = open("biases_3layers.pickle", "wb")
 pickle.dump(biases, biases_pickle)
 biases_pickle.close()


### PR DESCRIPTION
all pickle files will be available in the repository's main directory,
even large training and test datasets that cannot be uploaded to github.